### PR TITLE
fix(https://github.com/PnX-SI/gn_mobile_occtax/issues/264): name permissions from applicationId

### DIFF
--- a/commons/src/main/AndroidManifest.xml
+++ b/commons/src/main/AndroidManifest.xml
@@ -3,14 +3,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="fr.geonature.sync.permission.READ" />
-    <uses-permission android:name="fr.geonature.sync.permission.WRITE" />
+    <uses-permission android:name="${applicationId}.provider.permission.READ" />
+    <uses-permission android:name="${applicationId}.provider.permission.WRITE" />
 
     <permission
-        android:name="fr.geonature.sync.permission.READ"
+        android:name="${applicationId}.provider.permission.READ"
         android:protectionLevel="signature" />
     <permission
-        android:name="fr.geonature.sync.permission.WRITE"
+        android:name="${applicationId}.provider.permission.WRITE"
         android:protectionLevel="signature" />
 
 </manifest>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-</resources>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <string name="app_name" translatable="false">commons</string>
-
-    <string name="permission_read" translatable="false">fr.geonature.sync.permission.READ</string>
-    <string name="permission_write" translatable="false">fr.geonature.sync.permission.WRITE</string>
-
-</resources>

--- a/docs/styles_themes.adoc
+++ b/docs/styles_themes.adoc
@@ -97,3 +97,23 @@ Then, we can edit each `strings.xml` file and keep only the node containing the 
 Gradle will simply merge the default resources (`src/main/res`) with the resources of the variant
 selected during the build. So you don't need to keep everything copied to the variant but just take
 the resources we want to replace.
+
+== Application ID
+
+Changing the app name doesn't prevent conflicts with other Occtax applications. If you think your users may install and use your application alongside another Occtax applications, you may want to change it's ID in the `occtax/build.gradle` file, so that the terminal can understand it's a distinct application.
+
+[source,gradle]
+----
+android {
+    // ...
+    defaultConfig {
+        applicationId "fr.geonature.myocctax"
+        // ...
+    }
+    // ...
+}
+----
+
+Be aware that if you do so, your application will be treated by the user's terminal as a different app from any previous version. Opening the new apk will not launch an update of the existing app, but the installation of a new one. To obtain the new version, users will have to fully uninstall the previous version before. Therefore, it is preferable to make this change before you release your application.
+
+Changing the ID also changes the repository where the application files are located (settings, local db). Don't forget to set the `gn_commons.t_mobile_apps.package` field accordingly in your GeoNature instance.


### PR DESCRIPTION
This pull request changes the way read and write permissions are named, in order to use the `applicationId` defined for the app in `occtax/build.gradle` file. This makes more convenient for developpers to create an application that can be installed and used alongside other Occtax applications.

Also, add some documentation in the `style_theme.adoc` section to better explain how to perform this customization, and the implication of such a modification.